### PR TITLE
feat!: remove options.welcomeMessage from Client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,6 @@ export default class Client extends (EventEmitter as unknown as new () => TypedE
     printErrors: boolean;
     helpSuffix: string;
     blockSelf: boolean;
-    welcomeMessage: string;
     apikey?: string;
     unescapeMessages: boolean;
     helpCommandLimit: number;
@@ -92,7 +91,6 @@ export default class Client extends (EventEmitter as unknown as new () => TypedE
         this.bot = options.bot ?? true;
         this.blockBots = options.blockBots ?? this.bot;
         this.blockSelf = options.blockSelf ?? this.bot;
-        this.welcomeMessage = options.welcomeMessage ?? ((this.bot && this.mainPrefix) ? `Hi there! I'm ${name}. Send ${this.mainPrefix}help for a list of commands.` : "");
 
         this.commands.help = helpCommand(this);
     }
@@ -131,7 +129,6 @@ export default class Client extends (EventEmitter as unknown as new () => TypedE
                     userID = authenticatedUserID;
                     this.#sessionID = sessionID;
 
-                    if (this.welcomeMessage) this.sendMessage(this.welcomeMessage);
                     if (this.blockSelf) this.blockedSessionIDs.add(this.sessionID);
                 })
                 .on("auth-error", ({ reason }) => {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -92,12 +92,6 @@ export interface ClientOptions {
     blockSelf?: boolean,
 
     /**
-     * A message to send when the bot joins.
-     * @default "Hi there! I'm ${client.name}. Send ${client.mainPrefix}help for a list of commands."
-     */
-    welcomeMessage?: string,
-
-    /**
      * The main prefix to use in commands (for example, the help command will use this to tell the user what prefix they should use).
      * This shouldn't have regex in it (although you can) because the average user can't read that.
      * Set this to an empty string to disable the command system.


### PR DESCRIPTION
Welcome messages are unnecessary and extra spammy when the bot restarts several times during testing.
As a general rule on msgroom, **bots should not send messages if the user doesn't explicitly ask for them**. Welcome messages fit into this rule, so let's remove them.
